### PR TITLE
Switched from using C standard double to BigFloat library

### DIFF
--- a/interpretator/Makefile
+++ b/interpretator/Makefile
@@ -3,7 +3,10 @@ GCC=gcc
 EMCC=emcc
 ARGS=-Wall -g -ggdb
 WASM_ARGS=-fno-exceptions -fno-rtti -s ENVIRONMENT=web -s MALLOC=dlmalloc -s DISABLE_EXCEPTION_CATCHING=1 -s NO_FILESYSTEM=1 -s WASM=1 -s ALLOW_MEMORY_GROWTH=1 -s MAXIMUM_MEMORY=4GB -s WASM_BIGINT -g
-LIBS=
+LIBDIR=libs
+LIBFILES=$(wildcard $(LIBDIR)/*/src/*.c)
+LIBS=$(wildcard $(LIBDIR)/*)
+INC:=$(INC) -I$(wildcard $(LIBDIR)/*/include)
 SRCDIR=src
 OBJDIR=obj
 FILES=$(wildcard $(SRCDIR)/*.c)
@@ -11,16 +14,24 @@ OBJS=$(FILES:$(SRCDIR)/%.c=$(OBJDIR)/%.o)
 BUILD=build
 EXEC=program
 
-all: clean_objs setup $(OBJS) $(EXEC)
+.PHONY: $(LIBS)
 
-setup:
+all: clean_objs setup libraries $(OBJS) $(EXEC)
+
+setup: $(OBJDIR)
 	@mkdir -pv $(BUILD)
 
 $(EXEC):
-	$(GCC) $(OBJS) $(ARGS) -lm -o $(BUILD)/$(EXEC)
+	$(GCC) $(wildcard $(OBJDIR)/*.o) $(ARGS) -lm -o $(BUILD)/$(EXEC)
 
 $(OBJDIR)/%.o: $(SRCDIR)/%.c $(OBJDIR)
 	$(GCC) $(ARGS) $(INC) -c $< -o $@
+
+libraries: $(LIBS)
+	@mv libs/*/obj/* $(OBJDIR) -v
+
+$(LIBS):
+	cd $@ && $(MAKE)
 
 $(OBJDIR):
 	@mkdir -pv $@

--- a/interpretator/include/misc.h
+++ b/interpretator/include/misc.h
@@ -1,13 +1,20 @@
 #ifndef misc_h
 #define misc_h
 
+#include "bigfloat.h"
+
 #define FLOAT_MAX_PRECISION                 6	  // Maximum level of precision when representing floating point values
 #define FLOAT_PRECISION_COMPENSATE_EXPONENT 1e-7  // Used to offset precision in floating point values to a more precise readable format
 #define STRING_MEMORY_MAX_LENGTH            4096  // Maximum length of a string
 
-unsigned char int_to_str(int n, char str[], int padding);
-void float_to_string(double n, char *res);
-void bool_to_string(double n, char *res);
+#if STRING_MEMORY_MAX_LENGTH < (BIGFLOAT_PRECISION + 2)
+#error `STRING_MEMORY_MAX_LENGTH` needs to be bigger!
+#endif
+
+char *int_to_string(BigFloat *n);
+char *float_to_string(BigFloat *n);
+char *bool_to_string(BigFloat *n);
+void fatal_error(unsigned int error_code);
 char *new_string();
 char *new_string_size(unsigned short size);
 

--- a/interpretator/include/scope.h
+++ b/interpretator/include/scope.h
@@ -1,6 +1,8 @@
 #ifndef scope_h
 #define scope_h
 
+#include "bigfloat.h"
+
 #define SCOPE_SUCCESS               0   // Successful operation
 #define SCOPE_FAILURE               1   // Failed operation
 #define SCOPE_CREATION_FAILURE      2   // Failed to allocate memory for new scope
@@ -49,13 +51,14 @@ struct scope_t
 	unsigned char type;    // Branch type
 	union result
 	{
-		double numeric;
+		BigFloat *numeric;
 		char *string;
 	} result;                  // Branch result
 	unsigned char result_type; // Branch result type
 	unsigned char await;       // Branch is awaiting result
 } __attribute__((__packed__));
 
+void scope_init();
 struct scope_t *scope_new();
 int scope_set_type(struct scope_t *scope, int set_type);
 int scope_get_type(struct scope_t *scope);
@@ -65,14 +68,18 @@ void scope_set_right(struct scope_t *scope, struct scope_t *set_scope);
 struct scope_t *scope_get_right(struct scope_t *scope);
 char* scope_traverse_string(struct scope_t *scope);
 void scope_destroy(struct scope_t *scope);
-void scope_set_result(struct scope_t *scope, double set_result);
+void scope_set_result(struct scope_t *scope, BigFloat *set_result);
 unsigned char scope_set_result_string(struct scope_t *scope, char *str);
 void scope_set_result_type(struct scope_t *scope, int set_result_type);
-double scope_get_result(struct scope_t *scope);
+BigFloat * scope_get_result(struct scope_t *scope);
 char *scope_get_result_string(struct scope_t *scope);
 int scope_get_result_type(struct scope_t *scope);
 void scope_clear_result(struct scope_t *scope);
 int scope_await(struct scope_t *scope);
 int scope_array_append(struct scope_t *scope_destination, struct scope_t *scope_source);
+BigFloat *scope_boolean_bigfloat_true();
+BigFloat *scope_boolean_bigfloat_false();
+#define SCOPE_BOOLEAN_BIGFLOAT_TRUE scope_boolean_bigfloat_true()
+#define SCOPE_BOOLEAN_BIGFLOAT_FALSE scope_boolean_bigfloat_false()
 
 #endif

--- a/interpretator/include/variable.h
+++ b/interpretator/include/variable.h
@@ -32,7 +32,7 @@ void variable_initialisation();
 unsigned int new_variable(unsigned int execution_scope, unsigned int function_scope, unsigned int variable_hash);
 void refresh_variable_scope(unsigned int variable_hash, unsigned int function_scope, unsigned int execution_scope);
 void delete_variable(variable_id id);
-struct scope_t *variable_get_scope(unsigned int variable_hash, unsigned int function_scope);
+struct scope_t *variable_get_scope(BigFloat *variable_hash_bigfloat, unsigned int function_scope);
 void cleanup(unsigned int execution_scope);
 
 #endif

--- a/interpretator/libs/BigFloat/Makefile
+++ b/interpretator/libs/BigFloat/Makefile
@@ -1,0 +1,18 @@
+GCC=gcc
+LIBNAME=BigFloat_
+INC=-I./include
+SRCDIR=src
+OBJDIR=obj
+FILES=$(wildcard $(SRCDIR)/*.c)
+OBJS=$(FILES:$(SRCDIR)/%.c=$(OBJDIR)/%.o)
+
+all: clean setup $(OBJS)
+
+setup:
+	@mkdir -pv $(OBJDIR)
+
+clean:
+	@rm -rvf $(OBJDIR)
+
+$(OBJDIR)/%.o: $(SRCDIR)/%.c
+	$(GCC) $(INC) -c $< -o $@ -g -ggdb

--- a/interpretator/libs/BigFloat/include/bigfloat.h
+++ b/interpretator/libs/BigFloat/include/bigfloat.h
@@ -1,0 +1,36 @@
+#ifndef BIG_FLOAT_H
+#define BIG_FLOAT_H
+
+#define BIGFLOAT_PRECISION 512
+
+typedef struct bigfloat {
+  unsigned char digits[BIGFLOAT_PRECISION];
+  short decimal;
+  unsigned char negative;
+} BigFloat;
+
+BigFloat *create(char *);
+BigFloat *createFromInt(int);
+void freeBigFloat(BigFloat *);
+void parse(BigFloat *, char *);
+char *toString(BigFloat *, unsigned char);
+void add(BigFloat *, BigFloat *, BigFloat *);
+void subtract(BigFloat *, BigFloat *, BigFloat *);
+void multiply(BigFloat *, BigFloat *, BigFloat *);
+char divide(BigFloat *, BigFloat *, BigFloat *);
+char modulo(BigFloat *, BigFloat *, BigFloat *);
+char equals(BigFloat *, BigFloat *);
+char equalsUpTo(BigFloat *, BigFloat *, int);
+char compare(BigFloat *, BigFloat *);
+char compareDifference(BigFloat *a, BigFloat *b);
+void clear(BigFloat *);
+void standardizeDecimal(BigFloat *, BigFloat *);
+void multiplyLine(BigFloat *, BigFloat *, int);
+void zerosFirst(BigFloat *);
+void intConvert(BigFloat *);
+void trailingZeros(BigFloat *);
+void shiftDownBy(char *, int, int);
+void shiftUpBy(char *, int, int);
+int toInt(BigFloat *);
+
+#endif

--- a/interpretator/libs/BigFloat/src/bigfloat.c
+++ b/interpretator/libs/BigFloat/src/bigfloat.c
@@ -1,0 +1,551 @@
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include "bigfloat.h"
+
+/*
+* Create BigFloat from char array, and return the pointer.
+*/
+BigFloat *create(char *str)
+{
+    int i;
+    BigFloat *res;
+    res = malloc(sizeof(BigFloat));
+    res->decimal = 1;
+    for (i = 0; i < BIGFLOAT_PRECISION; i++)
+    {
+        res->digits[i] = 0;
+    }
+    res->negative = 0;
+    parse(res, str);
+    return res;
+}
+
+/*
+* Create BigFloat from integer value, and return the pointer.
+*/
+BigFloat *createFromInt(int value)
+{
+    int i;
+    BigFloat *res;
+    res = malloc(sizeof(BigFloat));
+    res->decimal = 1;
+    for (i = 0; i < BIGFLOAT_PRECISION; i++)
+    {
+        res->digits[i] = 0;
+    }
+    res->negative = (value < 0);
+    int valueSize = (floor(log10(abs(value))) + 1);
+    for (i = 0; i < valueSize; i++)
+    {
+        res->digits[i] = value % 10;
+        value /= 10;
+        res->decimal++;
+    }
+    return res;
+}
+
+void freeBigFloat(BigFloat *b)
+{
+    if (b != NULL)
+        free(b);
+}
+
+/*
+* Parses in a string representing a floating point number and creates a
+* BigFloat out of the string representation.
+*/
+void parse(BigFloat *b, char *str)
+{
+    if (str == NULL)
+    {
+        clear(b);
+        b->negative = 0;
+        b->decimal = 1;
+        return;
+    }
+    b->decimal = 0;
+    int i = 0;
+    int index = 0;
+    if (str[0] == '-')
+    {
+        b->negative = 1;
+        i = 1;
+    }
+    else
+    {
+        b->negative = 0;
+    }
+    for (; i < strlen(str) && index < BIGFLOAT_PRECISION; i++)
+    {
+        if (str[i] == '.')
+        {
+            b->decimal = (b->negative) ? i - 1 : i;
+        }
+        else
+        {
+            b->digits[index++] = str[i] - '0';
+        }
+    }
+    if (b->decimal == 0)
+        b->decimal = (strlen(str) - b->negative);
+}
+
+/*
+* Converts BigFloat into a char array.
+*/
+char *toString(BigFloat *b, unsigned char decimals)
+{
+    const unsigned short length = (BIGFLOAT_PRECISION + b->negative + 1);
+    char *str = malloc(sizeof(char) * (BIGFLOAT_PRECISION + 2));
+    if (str == NULL)
+        return NULL;
+    memcpy((str + b->negative), b->digits, (BIGFLOAT_PRECISION + b->negative));
+    if (b->negative)
+        str[0] = '-';
+    short i;
+    if (decimals)
+    {
+        for (i = (BIGFLOAT_PRECISION + b->negative); i > b->decimal; i--)
+        {
+            if (str[(i - 1)] != 0)
+                break;
+        }
+    }
+    else
+        i = b->decimal;
+    for (short ii = b->negative; ii < i; ii++)
+        str[ii] += '0';
+    memset((str + i), 0, (length - i));
+    str[i] = '\0';
+    unsigned short new_length = (sizeof(char) * (i + (decimals != 0) + b->negative + 1));
+    char *str_short = realloc(str, new_length);
+    if (str_short != NULL)
+    {
+        str = str_short;
+        str[(i + (decimals != 0) + b->negative)] = '\0';
+    }
+    if (decimals)
+    {
+        memmove((str + b->negative + b->decimal + 1), (str + b->negative + b->decimal), (new_length - b->decimal));
+        str[(b->negative + b->decimal)] = '.';
+    }
+    return str;
+}
+
+/*
+* Adds two BigFloats and puts the result in the first parameter.
+*/
+void add(BigFloat *a, BigFloat *b, BigFloat *res)
+{
+    int i, result;
+    int carry = 0;
+    standardizeDecimal(a, b);
+    clear(res);
+    res->decimal = a->decimal;
+    unsigned char additionType = (a->negative + b->negative);
+    if (additionType != 1)
+    {
+        for (i = BIGFLOAT_PRECISION - 1; i >= 0; i--)
+        {
+            result = carry;
+            result += a->digits[i] + b->digits[i];
+            carry = result / 10;
+            res->digits[i] = result % 10;
+        }
+        if (carry != 0)
+        {
+            shiftDownBy((char *)res->digits, BIGFLOAT_PRECISION, 1);
+            res->decimal++;
+            res->digits[0] = carry;
+        }
+        trailingZeros(a);
+        trailingZeros(b);
+        trailingZeros(res);
+        if (additionType == 2)
+            res->negative = 1;
+    }
+    else if (a->negative)
+    {
+        b->negative = 1;
+        subtract(b, a, res);
+        b->negative = 0;
+    }
+    else if (b->negative)
+    {
+        a->negative = 1;
+        subtract(a, b, res);
+        a->negative = 0;
+    }
+}
+
+/*
+* Subtract b from a and return a new BigFloat as the result.
+*/
+void subtract(BigFloat *a, BigFloat *b, BigFloat *res)
+{
+    int i, result;
+    int carry = 0;
+    BigFloat *top, *bottom;
+    standardizeDecimal(a, b);
+    clear(res);
+    res->decimal = a->decimal;
+    if (compare(a, b) >= 0)
+    {
+        top = a;
+        bottom = b;
+    }
+    else
+    {
+        top = b;
+        bottom = a;
+        res->negative = 1;
+    }
+    for (i = BIGFLOAT_PRECISION - 1; i >= 0; i--)
+    {
+        result = carry + top->digits[i];
+        if (result < bottom->digits[i])
+        {
+            carry = -1;
+            res->digits[i] = result + 10 - bottom->digits[i];
+        }
+        else
+        {
+            carry = 0;
+            res->digits[i] = result - bottom->digits[i];
+        }
+    }
+    trailingZeros(a);
+    trailingZeros(b);
+    trailingZeros(res);
+}
+
+void multiply(BigFloat *a, BigFloat *b, BigFloat *res)
+{
+    int i;
+    BigFloat *line = create(NULL);
+    BigFloat *temp = create(NULL);
+    clear(res);
+    res->decimal = BIGFLOAT_PRECISION;
+    line->decimal = BIGFLOAT_PRECISION;
+    zerosFirst(a);
+    zerosFirst(b);
+    for (i = BIGFLOAT_PRECISION - 1; i >= 0; i--)
+    {
+        multiplyLine(a, line, b->digits[i]);
+        shiftUpBy((char *)line->digits, BIGFLOAT_PRECISION, BIGFLOAT_PRECISION - i);
+        add(res, line, temp);
+        line->decimal = BIGFLOAT_PRECISION;
+        zerosFirst(temp);
+        memcpy(res, temp, sizeof(BigFloat));
+    }
+    res->decimal -= BIGFLOAT_PRECISION - a->decimal + BIGFLOAT_PRECISION - b->decimal + 1;
+    trailingZeros(a);
+    trailingZeros(b);
+    trailingZeros(res);
+    freeBigFloat(line);
+    line = NULL;
+    res->negative = ((a->negative || b->negative) && !(a->negative && b->negative)) ? 1 : 0;
+    freeBigFloat(temp);
+}
+
+void multiplyLine(BigFloat *a, BigFloat *line, int mult)
+{
+    int i, result;
+    int carry = 0;
+    for (i = BIGFLOAT_PRECISION - 1; i >= 0; i--)
+    {
+        result = carry;
+        result += a->digits[i] * mult;
+        carry = result / 10;
+        line->digits[i] = result % 10;
+    }
+}
+
+char divide(BigFloat *a, BigFloat *b, BigFloat *res)
+{
+    int i, counter;
+    int index = 0;
+    clear(res);
+    res->decimal = b->decimal;
+    if (equals(b, res))
+        return 1;
+    BigFloat *current = create(NULL);
+    BigFloat *temp = create(NULL);
+    current->decimal = 0;
+    res->decimal = a->decimal;
+    for (i = 0; i < BIGFLOAT_PRECISION; i++)
+    {
+        counter = 0;
+        current->digits[index++] = a->digits[i];
+        current->decimal++;
+        trailingZeros(current);
+        for (;compare(current, b) >= 0;)
+        {
+            subtract(current, b, temp);
+            memcpy(current, temp, sizeof(BigFloat));
+            counter++;
+        }
+        res->digits[i] = counter;
+    }
+    freeBigFloat(temp);
+    freeBigFloat(current);
+    trailingZeros(res);
+    return 0;
+}
+
+char modulo(BigFloat *a, BigFloat *b, BigFloat *res)
+{
+    BigFloat *temp = create(NULL);
+    BigFloat *temp2 = create(NULL);
+    BigFloat *temp3 = create("0.5");
+    clear(res);
+    if (equals(b, res))
+        return 1;
+    divide(a, b, temp);
+    memcpy(temp2, temp, sizeof(BigFloat));
+    intConvert(temp);
+    if (temp->negative)
+    {
+        // BigFloat *temp4 = create(NULL);
+        // subtract(temp, temp3, temp4);
+        // intConvert(temp4);
+        // if (!equals(temp, temp4))
+        //     memcpy(temp, temp4, sizeof(BigFloat));
+        // freeBigFloat(temp4);
+    }
+    multiply(temp, b, temp2);
+    subtract(a, temp2, res);
+    freeBigFloat(temp);
+    freeBigFloat(temp2);
+    freeBigFloat(temp3);
+    return 0;
+}
+
+/*
+* Tests whether or not two BigFloats are equal.
+*/
+char equals(BigFloat *a, BigFloat *b)
+{
+    int i;
+    if (a == b)
+    {
+        return 1;
+    }
+    else
+    {
+        if (a->decimal == b->decimal && a->negative == b->negative)
+        {
+            for (i = 0; i < BIGFLOAT_PRECISION; i++)
+            {
+                if (a->digits[i] != b->digits[i])
+                {
+                    return 0;
+                }
+            }
+            return 1;
+        }
+        else
+        {
+            return 0;
+        }
+    }
+}
+
+/*
+* Tests whether or not two BigFloats are equal up to the given decimal place.
+*/
+char equalsUpTo(BigFloat *a, BigFloat *b, int decimal)
+{
+    int i;
+    if (a == b)
+    {
+        return 1;
+    }
+    else
+    {
+        if (a->decimal == b->decimal && a->negative == b->negative)
+        {
+            for (i = 0; i < a->decimal + decimal; i++)
+            {
+                if (a->digits[i] != b->digits[i])
+                {
+                    return 0;
+                }
+            }
+            return 1;
+        }
+        else
+        {
+            return 0;
+        }
+    }
+}
+
+/*
+* Compares two BigFloats so that compare(a, b) > 0 if
+* a > b and so on with = and <
+*/
+char compare(BigFloat *a, BigFloat *b)
+{
+    int i;
+    if (a == b)
+    {
+        return 0;
+    }
+    else
+    {
+        if (a->decimal != b->decimal)
+        {
+            return (char)a->decimal - b->decimal;
+        }
+        else
+        {
+            for (i = 0; i < BIGFLOAT_PRECISION; i++)
+            {
+                if (a->digits[i] != b->digits[i])
+                {
+                    return (char)a->digits[i] - b->digits[i];
+                }
+            }
+            return 0;
+        }
+    }
+}
+
+char compareDifference(BigFloat *a, BigFloat *b)
+{
+    standardizeDecimal(a, b);
+    if (a->negative && !b->negative)
+        return -1;
+    else if (!a->negative && b->negative)
+        return 1;
+    else if (a->digits < b->digits)
+        return !a->negative;
+    else if (a->digits > b->digits)
+        return !b->negative;
+    else
+        return 0;
+}
+
+/*
+* Shifts the BigFloat down so that there are not any trailing zeros and all
+* zeros are leading the BigFloat.
+*/
+void zerosFirst(BigFloat *a)
+{
+    int i, start;
+    for (i = BIGFLOAT_PRECISION - 1; i >= 0 && !a->digits[i]; i--)
+        ;
+    start = i;
+    shiftDownBy((char *)a->digits, BIGFLOAT_PRECISION, BIGFLOAT_PRECISION - start - 1);
+    a->decimal += BIGFLOAT_PRECISION - start - 1;
+}
+
+/*
+* Removes any digits after decimal position.
+*/
+void intConvert(BigFloat *a)
+{
+    int i;
+    for (i = (BIGFLOAT_PRECISION - 1); i >= a->decimal; i--)
+        a->digits[i] = 0;
+}
+
+/*
+* Shifts the BigFloat down so that there are not any leading zeros and all
+* zeros are trailing the BigFloat.
+*/
+void trailingZeros(BigFloat *a)
+{
+    int i, start;
+    for (i = 0; i < BIGFLOAT_PRECISION && !a->digits[i]; i++)
+        ;
+    if (a->decimal - i < 1)
+    {
+        i = a->decimal - 1;
+    }
+    start = i;
+    shiftUpBy((char *)a->digits, BIGFLOAT_PRECISION, start);
+    a->decimal -= start;
+}
+
+/*
+* Takes two BigFloats and shifts them so that they have the same decimal point.
+*/
+void standardizeDecimal(BigFloat *a, BigFloat *b)
+{
+    if (b->decimal > a->decimal)
+    {
+        shiftDownBy((char *)a->digits, BIGFLOAT_PRECISION, b->decimal - a->decimal);
+        a->decimal = b->decimal;
+    }
+    else if (b->decimal < a->decimal)
+    {
+        shiftDownBy((char *)b->digits, BIGFLOAT_PRECISION, a->decimal - b->decimal);
+        b->decimal = a->decimal;
+    }
+}
+
+/*
+* Shifts a char array down by the specified shift
+*/
+void shiftDownBy(char *ar, int length, int shift)
+{
+    int i;
+    for (i = length - 1; i >= 0; i--)
+    {
+        if (i - shift >= 0)
+        {
+            ar[i] = ar[i - shift];
+        }
+        else
+        {
+            ar[i] = 0;
+        }
+    }
+}
+
+/*
+* Shifts a char array up by the specified shift
+*/
+void shiftUpBy(char *ar, int length, int shift)
+{
+    int i;
+    for (i = 0; i < length; i++)
+    {
+        if (i + shift < length)
+        {
+            ar[i] = ar[i + shift];
+        }
+        else
+        {
+            ar[i] = 0;
+        }
+    }
+}
+
+void clear(BigFloat *a)
+{
+    int i;
+    if (a != NULL)
+    {
+        for (i = 0; i < BIGFLOAT_PRECISION; i++)
+        {
+            a->digits[i] = 0;
+        }
+    }
+}
+
+int toInt(BigFloat *a)
+{
+    int result = 0;
+    for (unsigned char i = 0; (i < a->decimal && i < 10); i++)
+    {
+        result *= 10;
+        result += a->digits[i];
+    }
+    if (a->negative)
+        result = (0 - result);
+    return result;
+}

--- a/interpretator/src/misc.c
+++ b/interpretator/src/misc.c
@@ -4,81 +4,47 @@
 #include <stdlib.h>
 #include <string.h>
 #include "misc.h"
+#include "run.h"
 #include "scope.h"
+#include "bigfloat.h"
 
-unsigned char int_to_str(int n, char str[], int padding)
+char * int_to_string(BigFloat *n)
 {
-	if (n == 0 && padding == 0)
-		padding = 1;
-	int i = 0;
-	if (n < 0)
-		str[i++] = '-';
-	while (n)
-	{
-		str[i++] = (n % 10) + '0'; // Convert last digit to ascii char
-		n = n / 10;
-	}
-
-	for (unsigned char ii = 0; ii < padding; ii++)
-		str[i++] = '0'; // Leftwards 0 padding
-	char str_tmp[i];
-	for (int ii = 0; ii < i; ii++)
-		str_tmp[ii] = str[(i - 1 - ii)];
-	for (int ii = 0; ii < i; ii++)
-		str[ii] = str_tmp[ii]; // Reverse char array
-	str[i] = '\0';
-	return i;
+	return toString(n, 0);
 }
 
-void float_to_string(double n, char *res)
+char * float_to_string(BigFloat *n)
 {
-	int whole_number = (int)n;					// Extract whole integer from double
-	double decimals = n - (double)whole_number; // Extract floating point decimal from double
-	unsigned char i = int_to_str(whole_number, res, (whole_number == 0));
-	unsigned char lessen[2] = {0, 0};
-	for (unsigned ii = 0; ii < FLOAT_MAX_PRECISION; ii++)
-	{
-		decimals *= 10;
-		if ((int)(decimals + FLOAT_PRECISION_COMPENSATE_EXPONENT) % 10 == 0 && lessen[1] == 0)
-			lessen[0]++; // Increase leftwards padding
-		else
-			lessen[1] = 1; // Decimal value is not completely 0
-	}
-	res[i++] = '.';
-	if (lessen[1] != 0)
-	{
-		while ((int)decimals % 10 == 0)
-			decimals /= 10;
-		decimals += FLOAT_PRECISION_COMPENSATE_EXPONENT; // Compensat for double precision inaccuracies
-		i += (int_to_str((int)decimals, (res + i), lessen[0]) - 1);
-		for (int ii = 0; ii < FLOAT_MAX_PRECISION; ii++)
-		{
-			if (res[i--] == '0')	 // If is trailing 0
-				res[(i + 1)] = '\0'; // Remove trailing 0
-			else
-			{
-				i += 2;
-				break;
-			}
-			if (ii == (FLOAT_MAX_PRECISION - 1))
-				i++;
-		}
-	}
-	else
-		res[i++] = '0';
-	res[i] = '\0';
+	return toString(n, 1);
 }
 
-void bool_to_string(double n, char *res)
+char * bool_to_string(BigFloat *n)
 {
-	if (n == SCOPE_BOOLEAN_TRUE)
+	char *res = NULL;
+	if (equals(n, SCOPE_BOOLEAN_BIGFLOAT_TRUE))
+	{
+		res = malloc(sizeof(char) * 5);
+		if (res == NULL)
+			fatal_error(RUN_MEMORY_ALLOCATION_ERROR);
 		strcpy(res, "True\0");
+	}
 	else
+	{
+		res = malloc(sizeof(char) * 6);
+		if (res == NULL)
+			fatal_error(RUN_MEMORY_ALLOCATION_ERROR);
 		strcpy(res, "False\0");
+	}
+	return res;
 }
 
 char *new_string() {
-	return malloc((sizeof(char) * STRING_MEMORY_MAX_LENGTH));
+	return malloc(STRING_MEMORY_MAX_LENGTH * sizeof(char));
+}
+
+void fatal_error(unsigned int error_code)
+{
+	exit(error_code);
 }
 
 char *new_string_size(unsigned short size) {

--- a/interpretator/src/run.c
+++ b/interpretator/src/run.c
@@ -50,7 +50,7 @@ int new_tree(int branch_position)
 struct position *new_branch()
 {
 	struct position *position_tree_node = (struct position *)malloc(sizeof(struct position)); // Allocate a new position node
-	if (position_tree_node != NULL)											 // If a position node was allocated
+	if (position_tree_node != NULL)															  // If a position node was allocated
 	{
 		position_tree_node->branch = RUN_POSITION_BRANCH_NULL; // Set branch direction to null
 		position_tree_node->next = NULL;					   // Set branch child to null
@@ -109,7 +109,7 @@ int step(struct scope_t *scope)
 			{
 			case SCOPE_LOGIC_AND:
 			{
-				scope_set_result(scope, (scope_get_result(scope_get_left(scope)) == SCOPE_BOOLEAN_TRUE && scope_get_result(scope_get_right(scope)) == SCOPE_BOOLEAN_TRUE));
+				scope_set_result(scope, createFromInt(equals(scope_get_result(scope_get_left(scope)), SCOPE_BOOLEAN_BIGFLOAT_TRUE) && equals(scope_get_result(scope_get_right(scope)), SCOPE_BOOLEAN_BIGFLOAT_TRUE)));
 				break;
 			}
 			case SCOPE_LOGIC_NOT:
@@ -117,14 +117,14 @@ int step(struct scope_t *scope)
 				if (scope_get_result_type(scope_get_left(scope)) == SCOPE_TYPE_STRING)
 				{
 					if (strlen(scope_get_result_string(variable_get_scope(scope_get_result(scope_get_left(scope)), function_scope))) == 0)
-						scope_set_result(scope, SCOPE_BOOLEAN_TRUE);
+						scope_set_result(scope, SCOPE_BOOLEAN_BIGFLOAT_TRUE);
 					else
-						scope_set_result(scope, SCOPE_BOOLEAN_FALSE);
+						scope_set_result(scope, SCOPE_BOOLEAN_BIGFLOAT_FALSE);
 				}
-				else if (scope_get_result(scope_get_left(scope)) == SCOPE_BOOLEAN_TRUE)
-					scope_set_result(scope, SCOPE_BOOLEAN_FALSE);
+				else if (equals(scope_get_result(scope_get_left(scope)), SCOPE_BOOLEAN_BIGFLOAT_TRUE))
+					scope_set_result(scope, SCOPE_BOOLEAN_BIGFLOAT_FALSE);
 				else
-					scope_set_result(scope, SCOPE_BOOLEAN_TRUE);
+					scope_set_result(scope, SCOPE_BOOLEAN_BIGFLOAT_TRUE);
 				break;
 			}
 			case SCOPE_LOGIC_EQUAL:
@@ -132,16 +132,16 @@ int step(struct scope_t *scope)
 				if (scope_get_result_type(scope_get_left(scope)) == SCOPE_TYPE_STRING && scope_get_result_type(scope_get_right(scope)) == SCOPE_TYPE_STRING)
 				{
 					if (strcmp(scope_get_result_string(variable_get_scope(scope_get_result(scope_get_left(scope)), function_scope)), scope_get_result_string(variable_get_scope(scope_get_result(scope_get_left(scope)), function_scope))) == 0)
-						scope_set_result(scope, SCOPE_BOOLEAN_TRUE);
+						scope_set_result(scope, SCOPE_BOOLEAN_BIGFLOAT_TRUE);
 					else
-						scope_set_result(scope, SCOPE_BOOLEAN_FALSE);
+						scope_set_result(scope, SCOPE_BOOLEAN_BIGFLOAT_FALSE);
 				}
 				else if ((scope_get_result_type(scope_get_left(scope)) == SCOPE_TYPE_STRING && scope_get_result_type(scope_get_right(scope)) != SCOPE_TYPE_STRING) || (scope_get_result_type(scope_get_left(scope)) != SCOPE_TYPE_STRING && scope_get_result_type(scope_get_right(scope)) == SCOPE_TYPE_STRING))
-					scope_set_result(scope, SCOPE_BOOLEAN_FALSE);
+					scope_set_result(scope, SCOPE_BOOLEAN_BIGFLOAT_FALSE);
 				else if (scope_get_result(scope_get_left(scope)) == scope_get_result(scope_get_right(scope)))
-					scope_set_result(scope, SCOPE_BOOLEAN_TRUE);
+					scope_set_result(scope, SCOPE_BOOLEAN_BIGFLOAT_TRUE);
 				else
-					scope_set_result(scope, SCOPE_BOOLEAN_FALSE);
+					scope_set_result(scope, SCOPE_BOOLEAN_BIGFLOAT_FALSE);
 				break;
 			}
 			case SCOPE_LOGIC_LESS:
@@ -151,9 +151,9 @@ int step(struct scope_t *scope)
 				else if (scope_get_type(scope_get_left(scope)) == SCOPE_TYPE_ARRAY || scope_get_type(scope_get_right(scope)) == SCOPE_TYPE_ARRAY)
 					return RUN_ARRAY_LOGIC_ERROR;
 				if (scope_get_result(scope_get_left(scope)) < scope_get_result(scope_get_right(scope)))
-					scope_set_result(scope, SCOPE_BOOLEAN_TRUE);
+					scope_set_result(scope, SCOPE_BOOLEAN_BIGFLOAT_TRUE);
 				else
-					scope_set_result(scope, SCOPE_BOOLEAN_FALSE);
+					scope_set_result(scope, SCOPE_BOOLEAN_BIGFLOAT_FALSE);
 				break;
 			}
 			case SCOPE_LOGIC_LESS_OR_EQUAL:
@@ -163,9 +163,9 @@ int step(struct scope_t *scope)
 				else if (scope_get_type(scope_get_left(scope)) == SCOPE_TYPE_ARRAY || scope_get_type(scope_get_right(scope)) == SCOPE_TYPE_ARRAY)
 					return RUN_ARRAY_LOGIC_ERROR;
 				if (scope_get_result(scope_get_left(scope)) <= scope_get_result(scope_get_right(scope)))
-					scope_set_result(scope, SCOPE_BOOLEAN_TRUE);
+					scope_set_result(scope, SCOPE_BOOLEAN_BIGFLOAT_TRUE);
 				else
-					scope_set_result(scope, SCOPE_BOOLEAN_FALSE);
+					scope_set_result(scope, SCOPE_BOOLEAN_BIGFLOAT_FALSE);
 				break;
 			}
 			case SCOPE_LOGIC_MORE:
@@ -175,9 +175,9 @@ int step(struct scope_t *scope)
 				else if (scope_get_type(scope_get_left(scope)) == SCOPE_TYPE_ARRAY || scope_get_type(scope_get_right(scope)) == SCOPE_TYPE_ARRAY)
 					return RUN_ARRAY_LOGIC_ERROR;
 				if (scope_get_result(scope_get_left(scope)) > scope_get_result(scope_get_right(scope)))
-					scope_set_result(scope, SCOPE_BOOLEAN_TRUE);
+					scope_set_result(scope, SCOPE_BOOLEAN_BIGFLOAT_TRUE);
 				else
-					scope_set_result(scope, SCOPE_BOOLEAN_FALSE);
+					scope_set_result(scope, SCOPE_BOOLEAN_BIGFLOAT_FALSE);
 				break;
 			}
 			case SCOPE_LOGIC_MORE_OR_EQUAL:
@@ -187,9 +187,9 @@ int step(struct scope_t *scope)
 				else if (scope_get_type(scope_get_left(scope)) == SCOPE_TYPE_ARRAY || scope_get_type(scope_get_right(scope)) == SCOPE_TYPE_ARRAY)
 					return RUN_ARRAY_LOGIC_ERROR;
 				if (scope_get_result(scope_get_left(scope)) >= scope_get_result(scope_get_right(scope)))
-					scope_set_result(scope, SCOPE_BOOLEAN_TRUE);
+					scope_set_result(scope, SCOPE_BOOLEAN_BIGFLOAT_TRUE);
 				else
-					scope_set_result(scope, SCOPE_BOOLEAN_FALSE);
+					scope_set_result(scope, SCOPE_BOOLEAN_BIGFLOAT_FALSE);
 				break;
 			}
 			case SCOPE_MATH_ADD:
@@ -212,7 +212,7 @@ int step(struct scope_t *scope)
 				{
 					if (scope_get_type(scope_get_left(scope)) == SCOPE_TYPE_ARRAY && scope_get_type(scope_get_right(scope)) == SCOPE_TYPE_ARRAY)
 					{
-					//	scope_array_append()
+						//	scope_array_append()
 					}
 					else
 						return RUN_ARRAY_LOGIC_ERROR;
@@ -220,29 +220,32 @@ int step(struct scope_t *scope)
 				else
 					scope_set_result_type(scope, SCOPE_TYPE_STRING);
 				if (scope_get_result_type(scope) == SCOPE_TYPE_INT || scope_get_result_type(scope) == SCOPE_TYPE_DOUBLE)
-					scope_set_result(scope, (scope_get_result(scope_get_left(scope)) + scope_get_result(scope_get_right(scope))));
+				{
+					BigFloat *result = create(NULL);
+					add(scope_get_result(scope_get_left(scope)), scope_get_result(scope_get_right(scope)), result);
+					scope_set_result(scope, result);
+				}
 				else
 				{
 					// Result will be a string
 					unsigned int scope_current_size = scope_size();
 					char *temporary_strings[3] = {
 						// Utilise the current string value, or allocated memory for new conversions
-						((scope_get_type(scope_get_left(scope)) == SCOPE_TYPE_STRING) ? scope_get_result_string(variable_get_scope(scope_get_result(scope_get_left(scope)), function_scope)) : new_string()),
-						((scope_get_type(scope_get_right(scope)) == SCOPE_TYPE_STRING) ? scope_get_result_string(variable_get_scope(scope_get_result(scope_get_right(scope)), function_scope)) : new_string()),
-						NULL
-					};
+						((scope_get_type(scope_get_left(scope)) == SCOPE_TYPE_STRING) ? scope_get_result_string(variable_get_scope(scope_get_result(scope_get_left(scope)), function_scope)) : NULL),
+						((scope_get_type(scope_get_right(scope)) == SCOPE_TYPE_STRING) ? scope_get_result_string(variable_get_scope(scope_get_result(scope_get_right(scope)), function_scope)) : NULL),
+						NULL};
 					if (temporary_strings[0] == NULL || temporary_strings[1] == NULL) // Failed to allocate memory for temporary strings
 						return RUN_MEMORY_ALLOCATION_ERROR;
 					switch (scope_get_type(scope_get_left(scope)))
 					{
 					case SCOPE_TYPE_INT:
-						int_to_str((int)scope_get_result(scope_get_left(scope)), temporary_strings[0], 0);
+						temporary_strings[0] = int_to_string(scope_get_result(scope_get_left(scope)));
 						break;
 					case SCOPE_TYPE_DOUBLE:
-						float_to_string(scope_get_result(scope_get_left(scope)), temporary_strings[0]);
+						temporary_strings[0] = float_to_string(scope_get_result(scope_get_left(scope)));
 						break;
 					case SCOPE_TYPE_BOOL:
-						bool_to_string(scope_get_result(scope_get_left(scope)), temporary_strings[0]);
+						temporary_strings[0] = bool_to_string(scope_get_result(scope_get_left(scope)));
 						break;
 					default:
 						return RUN_CONVERTION_FAILURE; // Unknown scope type
@@ -250,13 +253,13 @@ int step(struct scope_t *scope)
 					switch (scope_get_type(scope_get_right(scope)))
 					{
 					case SCOPE_TYPE_INT:
-						int_to_str((int)scope_get_result(scope_get_right(scope)), temporary_strings[1], 0);
+						temporary_strings[1] = int_to_string(scope_get_result(scope_get_right(scope)));
 						break;
 					case SCOPE_TYPE_DOUBLE:
-						float_to_string(scope_get_result(scope_get_right(scope)), temporary_strings[1]);
+						temporary_strings[1] = float_to_string(scope_get_result(scope_get_right(scope)));
 						break;
 					case SCOPE_TYPE_BOOL:
-						bool_to_string(scope_get_result(scope_get_right(scope)), temporary_strings[1]);
+						temporary_strings[1] = bool_to_string(scope_get_result(scope_get_right(scope)));
 						break;
 					default:
 						return RUN_CONVERTION_FAILURE; // Unknown scope type
@@ -272,8 +275,8 @@ int step(struct scope_t *scope)
 					free(temporary_strings[0]);
 					strcat(temporary_strings[2], temporary_strings[1]); // Concatenate string values together
 					free(temporary_strings[1]);
-					scope_set_result(scope, new_variable(scope_current_size, function_scope, VARIABLE_TEMPORARY)); // Assign a new variable as a response value
-					scope_set_result_string(variable_get_scope(scope_get_result(scope), function_scope), temporary_strings[2]); // Assign a string value to response value
+					scope_set_result(scope, createFromInt(new_variable(scope_current_size, function_scope, VARIABLE_TEMPORARY))); // Assign a new variable as a response value
+					scope_set_result_string(variable_get_scope(scope_get_result(scope), function_scope), temporary_strings[2]);	  // Assign a string value to response value
 					free(temporary_strings[2]);
 				}
 				break;
@@ -284,14 +287,18 @@ int step(struct scope_t *scope)
 					return RUN_STRING_LOGIC_ERROR;
 				else if (scope_get_type(scope_get_left(scope)) == SCOPE_TYPE_ARRAY || scope_get_type(scope_get_right(scope)) == SCOPE_TYPE_ARRAY)
 					return RUN_ARRAY_LOGIC_ERROR;
-				scope_set_result(scope, (scope_get_result(scope_get_left(scope)) - scope_get_result(scope_get_right(scope))));
+				BigFloat *result = create(NULL);
+				subtract(scope_get_result(scope_get_left(scope)), scope_get_result(scope_get_right(scope)), result);
+				scope_set_result(scope, result);
 				break;
 			}
 			case SCOPE_MATH_MULTIPLY:
 			{
 				if (scope_get_result_type(scope_get_left(scope)) == SCOPE_TYPE_STRING || scope_get_result_type(scope_get_right(scope)) == SCOPE_TYPE_STRING)
 					return RUN_STRING_LOGIC_ERROR;
-				scope_set_result(scope, (scope_get_result(scope_get_left(scope)) * scope_get_result(scope_get_right(scope))));
+				BigFloat *result = create(NULL);
+				multiply(scope_get_result(scope_get_left(scope)), scope_get_result(scope_get_right(scope)), result);
+				scope_set_result(scope, result);
 				break;
 			}
 			case SCOPE_MATH_DIVIDE:
@@ -301,11 +308,15 @@ int step(struct scope_t *scope)
 				else if (scope_get_type(scope_get_left(scope)) == SCOPE_TYPE_ARRAY || scope_get_type(scope_get_right(scope)) == SCOPE_TYPE_ARRAY)
 					return RUN_ARRAY_LOGIC_ERROR;
 				if (scope_get_result(scope_get_right(scope)) == 0)
-					return RUN_FAILURE;						 // Zero devision error
-				else if (scope_get_result(scope_get_left(scope)) == 0) // Will always result in a value of zero
-					scope_set_result(scope, 0);				 // Set result to zero in order to avoid unnecessary mathmatical calculation
+					return RUN_FAILURE;																	// Zero devision error
+				else if (equals(scope_get_result(scope_get_left(scope)), SCOPE_BOOLEAN_BIGFLOAT_FALSE)) // Will always result in a value of zero
+					scope_set_result(scope, SCOPE_BOOLEAN_BIGFLOAT_FALSE);								// Set result to zero in order to avoid unnecessary mathmatical calculation
 				else
-					scope_set_result(scope, (scope_get_result(scope_get_left(scope)) / scope_get_result(scope_get_right(scope))));
+				{
+					BigFloat *result = create(NULL);
+					divide(scope_get_result(scope_get_left(scope)), scope_get_result(scope_get_right(scope)), result);
+					scope_set_result(scope, result);
+				}
 				break;
 			}
 			case SCOPE_MATH_MODULO:
@@ -315,11 +326,15 @@ int step(struct scope_t *scope)
 				else if (scope_get_type(scope_get_left(scope)) == SCOPE_TYPE_ARRAY || scope_get_type(scope_get_right(scope)) == SCOPE_TYPE_ARRAY)
 					return RUN_ARRAY_LOGIC_ERROR;
 				if (scope_get_result(scope_get_right(scope)) == 0)
-					return RUN_FAILURE;						 // Modulo zero error
-				else if (scope_get_result(scope_get_left(scope)) == 0) // Will always result in a value of zero
-					scope_set_result(scope, 0);				 // Set result to zero in order to avoid mathmatical calculation
+					return RUN_FAILURE;																	// Modulo zero error
+				else if (equals(scope_get_result(scope_get_left(scope)), SCOPE_BOOLEAN_BIGFLOAT_FALSE)) // Will always result in a value of zero
+					scope_set_result(scope, SCOPE_BOOLEAN_BIGFLOAT_FALSE);								// Set result to zero in order to avoid mathmatical calculation
 				else
-					scope_set_result(scope, fmod(scope_get_result(scope_get_left(scope)), scope_get_result(scope_get_right(scope))));
+				{
+					BigFloat *result = create(NULL);
+					modulo(scope_get_result(scope_get_left(scope)), scope_get_result(scope_get_right(scope)), result);
+					scope_set_result(scope, result);
+				}
 				break;
 			}
 			case SCOPE_VARIABLE:

--- a/interpretator/src/variable.c
+++ b/interpretator/src/variable.c
@@ -59,8 +59,9 @@ void delete_variable(variable_id id)
 	total_variables -= 1;								 // Decrease total variable count
 }
 
-struct scope_t *variable_get_scope(unsigned int variable_hash, unsigned int function_scope)
+struct scope_t *variable_get_scope(BigFloat *variable_hash_bigfloat, unsigned int function_scope)
 {
+	unsigned int variable_hash = toInt(variable_hash_bigfloat);
 	for (unsigned short i = 0; i < VARIABLE_MAX_TOTAL; i++)
 		if (variables[i].function_scope == function_scope || variables[i].function_scope == VARIABLE_SCOPE_GLOBAL)
 			if (variables[i].variable_hash == variable_hash)


### PR DESCRIPTION
Implemented changes to support the `BigFloat` library. Allowing for much larger floating point numerical values with elevated precision. This allows for any user generated input to not be limited by: the standard sizing, or precision; limitations that are in place within the use of the `double` datatype, and instead is limited to the bit sizing that is defined upon compilation.